### PR TITLE
Allow NULL values on newpoints_items

### DIFF
--- a/NewPoints Plugins/Shop 1.9.4/Upload/inc/plugins/newpoints/newpoints_shop.php
+++ b/NewPoints Plugins/Shop 1.9.4/Upload/inc/plugins/newpoints/newpoints_shop.php
@@ -82,7 +82,7 @@ function newpoints_shop_info()
 function newpoints_shop_install()
 {
 	global $db;
-	$db->write_query("ALTER TABLE `".TABLE_PREFIX."users` ADD `newpoints_items` TEXT NOT NULL;");
+	$db->write_query("ALTER TABLE `".TABLE_PREFIX."users` ADD `newpoints_items` TEXT;");
 	$db->write_query("ALTER TABLE `".TABLE_PREFIX."newpoints_grouprules` ADD `items_rate` DECIMAL(6,3) NOT NULL default 1.000;");
 
 	// add settings


### PR DESCRIPTION
With strict mode, new user registration was failing. newpoints_items supports NULL values in the code and allowing it on the column resolved my server 500 errors.